### PR TITLE
Add AVX512 support

### DIFF
--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         export EIGEN_PATH=`pwd`/include
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DEIGENRAND_CXX_FLAGS="-${{ matrix.arch }} -I${EIGEN_PATH}" ../
+        cmake -DCMAKE_BUILD_TYPE=Release -DEIGENRAND_CXX_FLAGS="-${{ matrix.arch }} -mavx512f -mfma -I${EIGEN_PATH}" ../
         make
     - name: Test
       run: |

--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        arch: [mavx512f]
+        arch: [mavx512dq]
         eigenversion: [3.4.0]
         os: [ubuntu-18.04]
     steps:

--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -65,7 +65,6 @@ jobs:
         git checkout v1.8.x
         popd
     - name: Build
-      continue-on-error: true
       run: |
         export EIGEN_PATH=`pwd`/include
         mkdir build && cd build
@@ -169,7 +168,6 @@ jobs:
         git checkout v1.8.x
         popd
     - name: Build
-      continue-on-error: true
       uses: lukka/run-cmake@v3
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced

--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -15,7 +15,43 @@ jobs:
         arch: [DEIGEN_DONT_VECTORIZE, msse2, mssse3, mavx, mavx2]
         eigenversion: [3.3.4, 3.3.5, 3.3.6, 3.3.7, 3.3.8, 3.3.9, 3.4.0]
         os: [ubuntu-18.04]
-    steps:        
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        git clone https://gitlab.com/libeigen/eigen
+        pushd eigen
+        git checkout tags/${{ matrix.eigenversion }}
+        popd
+        mv eigen include
+        git clone https://github.com/google/googletest
+        pushd googletest
+        git checkout v1.8.x
+        popd
+    - name: Build
+      continue-on-error: true
+      run: |
+        export EIGEN_PATH=`pwd`/include
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DEIGENRAND_CXX_FLAGS="-${{ matrix.arch }} -I${EIGEN_PATH}" ../
+        make
+    - name: Test
+      run: |
+        ./build/test/EigenRand-test
+    - name: Run Accuracy
+      run: |
+        ./build/EigenRand-accuracy
+
+  build_linux_avx512:
+    name: Build for linux AVX512
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        arch: [mavx512f]
+        eigenversion: [3.4.0]
+        os: [ubuntu-18.04]
+    steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: |
@@ -83,6 +119,43 @@ jobs:
       matrix:
         arch: ['/D EIGEN_DONT_VECTORIZE', '/arch:SSE2', '/arch:AVX', '/arch:AVX2']
         eigenversion: [3.3.4, 3.3.5, 3.3.6, 3.3.7, 3.3.8, 3.3.9, 3.4.0]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        Invoke-WebRequest -OutFile eigen.tar.gz https://gitlab.com/libeigen/eigen/-/archive/${{ matrix.eigenversion }}/eigen-${{ matrix.eigenversion }}.tar.gz
+        tar -zxvf eigen.tar.gz
+        mv eigen-${{ matrix.eigenversion }} include
+        echo "EIGEN_PATH=$(Get-Location)\include" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        git clone https://github.com/google/googletest
+        pushd googletest
+        git checkout v1.8.x
+        popd
+    - name: Build
+      continue-on-error: true
+      uses: lukka/run-cmake@v3
+      with:
+        cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+        cmakeBuildType: Release
+        buildWithCMake: true
+        cmakeAppendedArgs: -G"Visual Studio 16 2019" -Ax64 -DEIGENRAND_CXX_FLAGS="${{ matrix.arch }} /I${{ env.EIGEN_PATH }}"
+        buildWithCMakeArgs: --config Release
+        buildDirectory: build
+    - name: Test
+      run: |
+        .\build\test\Release\EigenRand-test.exe
+    - name: Run Accuracy
+      run: |
+        .\build\Release\EigenRand-accuracy.exe
+
+  build_windows_avx512:
+    name: Build for Windows
+    runs-on: windows-2019
+    strategy:
+      max-parallel: 4
+      matrix:
+        arch: ['/arch:AVX512']
+        eigenversion: [3.4.0]
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies

--- a/EigenRand/Dists/Basic.h
+++ b/EigenRand/Dists/Basic.h
@@ -333,9 +333,13 @@ namespace Eigen
 			template<typename Packet>
 			auto operator()(Packet v) -> uint64_t
 			{
+#ifdef EIGEN_VECTORIZE_AVX512
+				return Eigen::internal::pfirst(v);
+#else
 				uint64_t arr[sizeof(Packet) / 8];
 				Eigen::internal::pstoreu((Packet*)arr, v);
 				return arr[0];
+#endif
 			}
 		};
 

--- a/EigenRand/MorePacketMath.h
+++ b/EigenRand/MorePacketMath.h
@@ -569,6 +569,10 @@ namespace Eigen
 	}
 }
 
+#ifdef EIGEN_VECTORIZE_AVX512
+#include "arch/AVX512/MorePacketMath.h"
+#endif
+
 #ifdef EIGEN_VECTORIZE_AVX
 #include "arch/AVX/MorePacketMath.h"
 #endif

--- a/EigenRand/PacketFilter.h
+++ b/EigenRand/PacketFilter.h
@@ -27,6 +27,9 @@ namespace Eigen
 	}
 }
 
+#ifdef EIGEN_VECTORIZE_AVX512
+#include "arch/AVX512/PacketFilter.h"
+#endif
 
 #ifdef EIGEN_VECTORIZE_AVX
 #include "arch/AVX/PacketFilter.h"

--- a/EigenRand/RandUtils.h
+++ b/EigenRand/RandUtils.h
@@ -311,6 +311,9 @@ namespace Eigen
 	}
 }
 
+#ifdef EIGEN_VECTORIZE_AVX512
+#include "arch/AVX512/RandUtils.h"
+#endif
 
 #ifdef EIGEN_VECTORIZE_AVX
 #include "arch/AVX/RandUtils.h"

--- a/EigenRand/arch/AVX512/MorePacketMath.h
+++ b/EigenRand/arch/AVX512/MorePacketMath.h
@@ -174,7 +174,7 @@ namespace Eigen
 
 		template<> EIGEN_STRONG_INLINE bool predux_all(const Packet16f& x)
 		{
-			return predux_all(_mm512_castsi512_ps(x));
+			return predux_all(_mm512_castps_si512(x));
 		}
 
 		template<>

--- a/EigenRand/arch/AVX512/MorePacketMath.h
+++ b/EigenRand/arch/AVX512/MorePacketMath.h
@@ -1,0 +1,311 @@
+/**
+ * @file MorePacketMath.h
+ * @author bab2min (bab2min@gmail.com)
+ * @brief
+ * @version 0.5.0
+ * @date 2023-01-31
+ *
+ * @copyright Copyright (c) 2020-2021
+ *
+ */
+
+#ifndef EIGENRAND_MORE_PACKET_MATH_AVX512_H
+#define EIGENRAND_MORE_PACKET_MATH_AVX512_H
+
+#include <immintrin.h>
+
+namespace Eigen
+{
+	namespace internal
+	{
+		template<>
+		struct IsIntPacket<Packet16i> : std::true_type {};
+
+		template<>
+		struct HalfPacket<Packet16i>
+		{
+			using type = Packet8i;
+		};
+
+		template<>
+		struct HalfPacket<Packet16f>
+		{
+			using type = Packet8f;
+		};
+
+		template<>
+		struct IsFloatPacket<Packet16f> : std::true_type {};
+
+		template<>
+		struct IsDoublePacket<Packet8d> : std::true_type {};
+
+		template<>
+		struct reinterpreter<Packet16i>
+		{
+			EIGEN_STRONG_INLINE Packet16f to_float(const Packet16i& x)
+			{
+				return _mm512_castsi512_ps(x);
+			}
+
+			EIGEN_STRONG_INLINE Packet8d to_double(const Packet16i& x)
+			{
+				return _mm512_castsi512_pd(x);
+			}
+
+			EIGEN_STRONG_INLINE Packet16i to_int(const Packet16i& x)
+			{
+				return x;
+			}
+		};
+
+		template<>
+		struct reinterpreter<Packet16f>
+		{
+			EIGEN_STRONG_INLINE Packet16f to_float(const Packet16f& x)
+			{
+				return x;
+			}
+
+			EIGEN_STRONG_INLINE Packet8d to_double(const Packet16f& x)
+			{
+				return _mm512_castps_pd(x);
+			}
+
+			EIGEN_STRONG_INLINE Packet16i to_int(const Packet16f& x)
+			{
+				return _mm512_castps_si512(x);
+			}
+		};
+
+		template<>
+		struct reinterpreter<Packet8d>
+		{
+			EIGEN_STRONG_INLINE Packet16f to_float(const Packet8d& x)
+			{
+				return _mm512_castpd_ps(x);
+			}
+
+			EIGEN_STRONG_INLINE Packet8d to_double(const Packet8d& x)
+			{
+				return x;
+			}
+
+			EIGEN_STRONG_INLINE Packet16i to_int(const Packet8d& x)
+			{
+				return _mm512_castpd_si512(x);
+			}
+		};
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16i pseti64<Packet16i>(uint64_t a)
+		{
+			return _mm512_set1_epi64(a);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16i padd64<Packet16i>(const Packet16i& a, const Packet16i& b)
+		{
+			return _mm512_add_epi64(a, b);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16i psub64<Packet16i>(const Packet16i& a, const Packet16i& b)
+		{
+			return _mm512_sub_epi64(a, b);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16i pcmpeq<Packet16i>(const Packet16i& a, const Packet16i& b)
+		{
+			return pcmp_eq(a, b);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16f pcmpeq<Packet16f>(const Packet16f& a, const Packet16f& b)
+		{
+			return pcmp_eq(a, b);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16i pnegate<Packet16i>(const Packet16i& a)
+		{
+			return _mm512_sub_epi32(pset1<Packet16i>(0), a);
+		}
+
+		template<>
+		struct BitShifter<Packet16i>
+		{
+			template<int b>
+			EIGEN_STRONG_INLINE Packet16i sll(const Packet16i& a)
+			{
+				return _mm512_slli_epi32(a, b);
+			}
+
+			template<int b>
+			EIGEN_STRONG_INLINE Packet16i srl(const Packet16i& a, int _b = b)
+			{
+				if (b >= 0)
+				{
+					return _mm512_srli_epi32(a, b);
+				}
+				else
+				{
+					return _mm512_srli_epi32(a, _b);
+				}
+			}
+
+			template<int b>
+			EIGEN_STRONG_INLINE Packet16i sll64(const Packet16i& a)
+			{
+				return _mm512_slli_epi64(a, b);
+			}
+
+			template<int b>
+			EIGEN_STRONG_INLINE Packet16i srl64(const Packet16i& a)
+			{
+				return _mm512_srli_epi64(a, b);
+			}
+		};
+
+		template<> EIGEN_STRONG_INLINE bool predux_all(const Packet16i& x)
+		{
+			return _mm512_movepi32_mask(x) == 0xFFFF;
+		}
+
+		template<> EIGEN_STRONG_INLINE bool predux_all(const Packet16f& x)
+		{
+			return predux_all(_mm512_castsi512_ps(x));
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16i pcmplt<Packet16i>(const Packet16i& a, const Packet16i& b)
+		{
+			return pcmp_lt(a, b);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16f pcmplt<Packet16f>(const Packet16f& a, const Packet16f& b)
+		{
+			return pcmp_lt(a, b);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16f pcmple<Packet16f>(const Packet16f& a, const Packet16f& b)
+		{
+			return pcmp_le(a, b);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet8d pcmplt<Packet8d>(const Packet8d& a, const Packet8d& b)
+		{
+			return pcmp_lt(a, b);
+		}
+		template<>
+		EIGEN_STRONG_INLINE Packet8d pcmple<Packet8d>(const Packet8d& a, const Packet8d& b)
+		{
+			return pcmp_le(a, b);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16f pblendv(const Packet16i& ifPacket, const Packet16f& thenPacket, const Packet16f& elsePacket)
+		{
+			__mmask16 mask = _mm512_movepi32_mask(ifPacket);
+			return _mm512_mask_blend_ps(mask, elsePacket, thenPacket);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16f pblendv(const Packet16f& ifPacket, const Packet16f& thenPacket, const Packet16f& elsePacket)
+		{
+			return pblendv(_mm512_castps_si512(ifPacket), thenPacket, elsePacket);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16i pblendv(const Packet16i& ifPacket, const Packet16i& thenPacket, const Packet16i& elsePacket)
+		{
+			__mmask16 mask = _mm512_movepi32_mask(ifPacket);
+			return _mm512_mask_blend_epi32(mask, elsePacket, thenPacket);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet8d pblendv(const Packet16i& ifPacket, const Packet8d& thenPacket, const Packet8d& elsePacket)
+		{
+			__mmask8 mask = _mm512_movepi64_mask(ifPacket);
+			return _mm512_mask_blend_pd(mask, elsePacket, thenPacket);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet8d pblendv(const Packet8d& ifPacket, const Packet8d& thenPacket, const Packet8d& elsePacket)
+		{
+			return pblendv(_mm512_castpd_si512(ifPacket), thenPacket, elsePacket);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16i pgather<Packet16i>(const int* addr, const Packet16i& index)
+		{
+			return _mm512_i32gather_epi32(index, addr, 4);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16f pgather<Packet16i>(const float* addr, const Packet16i& index)
+		{
+			return _mm512_i32gather_ps(index, addr, 4);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet8d pgather<Packet16i>(const double* addr, const Packet16i& index, bool upperhalf)
+		{
+			return _mm512_i32gather_pd(_mm512_castsi512_si256(index), addr, 8);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16f ptruncate<Packet16f>(const Packet16f& a)
+		{
+			return _mm512_roundscale_ps(a, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet8d ptruncate<Packet8d>(const Packet8d& a)
+		{
+			return _mm512_roundscale_pd(a, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet16i pcmpeq64<Packet16i>(const Packet16i& a, const Packet16i& b)
+		{
+			__mmask16 mask = _mm512_cmp_epi64_mask(a, b, _MM_CMPINT_EQ);
+			return _mm512_mask_set1_epi64(_mm512_set1_epi64(0), mask, 0xfffffffffffffffful);
+		}
+
+		EIGEN_STRONG_INLINE __m512d int64_to_double_avx512(__m512i x) {
+			x = padd64(x, _mm512_castpd_si512(_mm512_set1_pd(0x0018000000000000)));
+			return _mm512_sub_pd(_mm512_castsi512_pd(x), _mm512_set1_pd(0x0018000000000000));
+		}
+
+		EIGEN_STRONG_INLINE __m512i double_to_int64_avx512(__m512d x) {
+			x = _mm512_add_pd(_mm512_floor_pd(x), _mm512_set1_pd(0x0018000000000000));
+			return psub64(
+				_mm512_castpd_si512(x),
+				_mm512_castpd_si512(_mm512_set1_pd(0x0018000000000000))
+			);
+		}
+		template<>
+		EIGEN_STRONG_INLINE Packet16i pcast64<Packet8d, Packet16i>(const Packet8d& a)
+		{
+			return double_to_int64_avx512(a);
+		}
+
+		template<>
+		EIGEN_STRONG_INLINE Packet8d pcast64<Packet16i, Packet8d>(const Packet16i& a)
+		{
+			return int64_to_double_avx512(a);
+		}
+
+		template<> EIGEN_DEFINE_FUNCTION_ALLOWING_MULTIPLE_DEFINITIONS EIGEN_UNUSED
+			Packet8d psin<Packet8d>(const Packet8d& x)
+		{
+			return _psin(x);
+		}
+	}
+}
+
+#endif

--- a/EigenRand/arch/AVX512/MorePacketMath.h
+++ b/EigenRand/arch/AVX512/MorePacketMath.h
@@ -181,7 +181,7 @@ namespace Eigen
 		EIGEN_STRONG_INLINE Packet16i pcmplt<Packet16i>(const Packet16i& a, const Packet16i& b)
 		{
 			__mmask16 mask = _mm512_cmp_epi32_mask(a, b, _MM_CMPINT_LT);
-			return _mm512_mask_set1_epi32(_mm512_set1_epi32(0), mask, 0xffffffffu);
+			return _mm512_movm_epi32(mask);
 		}
 
 		template<>
@@ -273,8 +273,8 @@ namespace Eigen
 		template<>
 		EIGEN_STRONG_INLINE Packet16i pcmpeq64<Packet16i>(const Packet16i& a, const Packet16i& b)
 		{
-			__mmask16 mask = _mm512_cmp_epi64_mask(a, b, _MM_CMPINT_EQ);
-			return _mm512_mask_set1_epi64(_mm512_set1_epi64(0), mask, 0xfffffffffffffffful);
+			__mmask8 mask = _mm512_cmp_epi64_mask(a, b, _MM_CMPINT_EQ);
+			return _mm512_movm_epi64(mask);
 		}
 
 		EIGEN_STRONG_INLINE __m512d int64_to_double_avx512(__m512i x) {

--- a/EigenRand/arch/AVX512/MorePacketMath.h
+++ b/EigenRand/arch/AVX512/MorePacketMath.h
@@ -180,7 +180,8 @@ namespace Eigen
 		template<>
 		EIGEN_STRONG_INLINE Packet16i pcmplt<Packet16i>(const Packet16i& a, const Packet16i& b)
 		{
-			return pcmp_lt(a, b);
+			__mmask16 mask = _mm512_cmp_epi32_mask(a, b, _MM_CMPINT_LT);
+			return _mm512_mask_set1_epi32(_mm512_set1_epi32(0), mask, 0xffffffffu);
 		}
 
 		template<>

--- a/EigenRand/arch/AVX512/PacketFilter.h
+++ b/EigenRand/arch/AVX512/PacketFilter.h
@@ -1,0 +1,79 @@
+/**
+ * @file PacketFilter.h
+ * @author bab2min (bab2min@gmail.com)
+ * @brief
+ * @version 0.5.0
+ * @date 2023-01-31
+ *
+ * @copyright Copyright (c) 2020-2021
+ *
+ */
+
+#ifndef EIGENRAND_PACKET_FILTER_AVX512_H
+#define EIGENRAND_PACKET_FILTER_AVX512_H
+
+#include <immintrin.h>
+
+namespace Eigen
+{
+	namespace Rand
+	{
+		namespace detail
+		{
+			template<>
+			class CompressMask<64>
+			{
+				CompressMask() {}
+
+			public:
+				enum { full_size = 16 };
+				static const CompressMask& get_inst()
+				{
+					static CompressMask cm;
+					return cm;
+				}
+
+				template<typename Packet>
+				EIGEN_STRONG_INLINE int compress_append(Packet& _value, const Packet& _mask,
+					Packet& _rest, int rest_cnt, bool& full) const
+				{
+					auto& value = reinterpret_cast<internal::Packet16f&>(_value);
+					auto& mask = reinterpret_cast<const internal::Packet16f&>(_mask);
+					auto& rest = reinterpret_cast<internal::Packet16f&>(_rest);
+
+					const __mmask16 m = _mm512_movepi32_mask(_mm512_castsi512_ps(mask));
+
+					if (m == 0xFFFF)
+					{
+						full = true;
+						return rest_cnt;
+					}
+
+					const int cnt_m = _mm_popcnt_u32(m);
+
+					const __m512i counting = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+					__m512i rotate = _mm512_sub_epi32(counting, _mm512_set1_epi32(cnt_m));
+					__m512 rot_rest = _mm512_permutexvar_ps(rotate, _rest);
+
+					__m512 p1 = _mm512_mask_compress_ps(rot_rest, m, value);
+
+					auto new_cnt = rest_cnt + cnt_m;
+					if (new_cnt >= full_size)
+					{
+						rest = rot_rest;
+						value = p1;
+						full = true;
+						return new_cnt - full_size;
+					}
+					else
+					{
+						rest = p1;
+						full = false;
+						return new_cnt;
+					}
+				}
+			};
+		}
+	}
+}
+#endif

--- a/EigenRand/arch/AVX512/PacketFilter.h
+++ b/EigenRand/arch/AVX512/PacketFilter.h
@@ -41,7 +41,7 @@ namespace Eigen
 					auto& mask = reinterpret_cast<const internal::Packet16f&>(_mask);
 					auto& rest = reinterpret_cast<internal::Packet16f&>(_rest);
 
-					const __mmask16 m = _mm512_movepi32_mask(_mm512_castsi512_ps(mask));
+					const __mmask16 m = _mm512_movepi32_mask(_mm512_castps_si512(mask));
 
 					if (m == 0xFFFF)
 					{
@@ -53,7 +53,7 @@ namespace Eigen
 
 					const __m512i counting = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
 					__m512i rotate = _mm512_sub_epi32(counting, _mm512_set1_epi32(cnt_m));
-					__m512 rot_rest = _mm512_permutexvar_ps(rotate, _rest);
+					__m512 rot_rest = _mm512_permutexvar_ps(rotate, rest);
 
 					__m512 p1 = _mm512_mask_compress_ps(rot_rest, m, value);
 

--- a/EigenRand/arch/AVX512/RandUtils.h
+++ b/EigenRand/arch/AVX512/RandUtils.h
@@ -1,0 +1,147 @@
+/**
+ * @file RandUtils.h
+ * @author bab2min (bab2min@gmail.com)
+ * @brief
+ * @version 0.5.0
+ * @date 2023-01-31
+ *
+ * @copyright Copyright (c) 2020-2021
+ *
+ */
+
+#ifndef EIGENRAND_RAND_UTILS_AVX512_H
+#define EIGENRAND_RAND_UTILS_AVX512_H
+
+#include <immintrin.h>
+
+namespace Eigen
+{
+	namespace internal
+	{
+		template<typename Rng>
+		struct RawbitsMaker<Packet8i, Rng, Packet16i, Rand::RandomEngineType::packet>
+		{
+			EIGEN_STRONG_INLINE Packet8i rawbits(Rng& rng)
+			{
+				return rng.half();
+			}
+
+			EIGEN_STRONG_INLINE Packet8i rawbits_34(Rng& rng)
+			{
+				return rng.half();
+			}
+
+			EIGEN_STRONG_INLINE Packet8i rawbits_half(Rng& rng)
+			{
+				return rng.half();
+			}
+		};
+
+		template<typename Rng>
+		struct RawbitsMaker<Packet16i, Rng, Packet8i, Rand::RandomEngineType::packet>
+		{
+			EIGEN_STRONG_INLINE Packet16i rawbits(Rng& rng)
+			{
+				return _mm512_inserti64x4(_mm512_castsi256_si512(rng()), rng(), 1);
+			}
+
+			EIGEN_STRONG_INLINE Packet16i rawbits_34(Rng& rng)
+			{
+				return _mm512_inserti64x4(_mm512_castsi256_si512(rng()), rng(), 1);
+			}
+
+			EIGEN_STRONG_INLINE Packet8i rawbits_half(Rng& rng)
+			{
+				return rng();
+			}
+		};
+
+		template<typename Rng, typename RngResult>
+		struct RawbitsMaker<Packet16i, Rng, RngResult, Rand::RandomEngineType::scalar_fullbit>
+		{
+			EIGEN_STRONG_INLINE Packet16i rawbits(Rng& rng)
+			{
+				if (sizeof(decltype(rng())) == 8)
+				{
+					return _mm512_set_epi64(rng(), rng(), rng(), rng(),
+						rng(), rng(), rng(), rng());
+				}
+				else
+				{
+					return _mm512_set_epi32(rng(), rng(), rng(), rng(),
+						rng(), rng(), rng(), rng(),
+						rng(), rng(), rng(), rng(),
+						rng(), rng(), rng(), rng());
+				}
+			}
+
+			EIGEN_STRONG_INLINE Packet16i rawbits_34(Rng& rng)
+			{
+				return rawbits(rng);
+			}
+
+			EIGEN_STRONG_INLINE Packet8i rawbits_half(Rng& rng)
+			{
+				if (sizeof(decltype(rng())) == 8)
+				{
+					return _mm256_set_epi64x(rng(), rng(), rng(), rng());
+				}
+				else
+				{
+					return _mm256_set_epi32(rng(), rng(), rng(), rng(),
+						rng(), rng(), rng(), rng());
+				}
+			}
+		};
+
+		template<typename Rng>
+		struct RawbitsMaker<Packet16i, Rng, Packet16i, Rand::RandomEngineType::packet>
+		{
+			EIGEN_STRONG_INLINE Packet16i rawbits(Rng& rng)
+			{
+				return rng();
+			}
+
+			EIGEN_STRONG_INLINE Packet16i rawbits_34(Rng& rng)
+			{
+				return rng();
+			}
+
+			EIGEN_STRONG_INLINE Packet8i rawbits_half(Rng& rng)
+			{
+				return rng.half();
+			}
+		};
+
+		template<typename Rng>
+		struct UniformRealUtils<Packet16f, Rng> : public RawbitsMaker<Packet16i, Rng>
+		{
+			EIGEN_STRONG_INLINE Packet16f zero_to_one(Rng& rng)
+			{
+				return pdiv(_mm512_cvtepi32_ps(pand(this->rawbits(rng), pset1<Packet16i>(0x7FFFFFFF))),
+					pset1<Packet16f>(0x7FFFFFFF));
+			}
+
+			EIGEN_STRONG_INLINE Packet16f uniform_real(Rng& rng)
+			{
+				return bit_to_ur_float(this->rawbits_34(rng));
+			}
+		};
+
+		template<typename Rng>
+		struct UniformRealUtils<Packet8d, Rng> : public RawbitsMaker<Packet16i, Rng>
+		{
+			EIGEN_STRONG_INLINE Packet8d zero_to_one(Rng& rng)
+			{
+				return pdiv(_mm512_cvtepi32_pd(pand(this->rawbits_half(rng), pset1<Packet8i>(0x7FFFFFFF))),
+					pset1<Packet8d>(0x7FFFFFFF));
+			}
+
+			EIGEN_STRONG_INLINE Packet8d uniform_real(Rng& rng)
+			{
+				return bit_to_ur_double(this->rawbits(rng));
+			}
+		};
+	}
+}
+#endif


### PR DESCRIPTION
This passes the tests here on zen4 with clang and `-march=x86-64-v4` and shows some performance improvements over a build without avx512 support (`-march=x86-64-v3`)

Runs of `EigenRand-benchmark`:
[benchmark-baseline.txt](https://github.com/bab2min/EigenRand/files/10982767/benchmark-baseline.txt)
[benchmark-avx512.txt](https://github.com/bab2min/EigenRand/files/10982766/benchmark-avx512.txt)
