### PR TITLE
Basic.h : add member function derived()

### DIFF
--- a/EigenRand/Dists/Basic.h
+++ b/EigenRand/Dists/Basic.h
@@ -33,6 +33,11 @@ namespace Eigen
 		{
 		public:
 			/**
+			 * @brief Return a reference to the derived type.
+			 */
+			DerivedGen &derived() { return static_cast<DerivedGen &>(*this); }
+
+			/**
 			 * @brief generate random values from its distribution
 			 * 
 			 * @tparam Derived 
@@ -48,7 +53,7 @@ namespace Eigen
 				generate(Index rows, Index cols, Urng&& urng)
 			{
 				return {
-					rows, cols, { std::forward<Urng>(urng), static_cast<DerivedGen&>(*this) }
+					rows, cols, { std::forward<Urng>(urng), derived() }
 				};
 			}
 
@@ -67,7 +72,7 @@ namespace Eigen
 				generateLike(const Derived& o, Urng&& urng)
 			{
 				return {
-					o.rows(), o.cols(), { std::forward<Urng>(urng), static_cast<DerivedGen&>(*this) }
+					o.rows(), o.cols(), { std::forward<Urng>(urng), derived() }
 				};
 			}
 		};
@@ -76,6 +81,11 @@ namespace Eigen
 		class UnaryGenBase
 		{
 		public:
+			/**
+			 * @brief Return a reference to the derived type.
+			 */
+			DerivedGen &derived() { return static_cast<DerivedGen &>(*this); }
+
 			/**
 			 * @brief generate random values from its distribution
 			 *
@@ -93,7 +103,7 @@ namespace Eigen
 			> generate(Urng&& urng, const ArrayBase<Lhs>& a)
 			{
 				return {
-					a, { std::forward<Urng>(urng), static_cast<DerivedGen&>(*this) }
+					a, { std::forward<Urng>(urng), derived() }
 				};
 			}
 		};
@@ -102,6 +112,11 @@ namespace Eigen
 		class BinaryGenBase
 		{
 		public:
+			/**
+			 * @brief Return a reference to the derived type.
+			 */
+			DerivedGen &derived() { return static_cast<DerivedGen &>(*this); }
+
 			/**
 			 * @brief generate random values from its distribution
 			 *
@@ -119,7 +134,7 @@ namespace Eigen
 			> generate(Urng&& urng, const ArrayBase<Lhs>& a, const ArrayBase<Rhs>& b)
 			{
 				return {
-					a, b, { std::forward<Urng>(urng), static_cast<DerivedGen&>(*this) }
+					a, b, { std::forward<Urng>(urng), derived() }
 				};
 			}
 
@@ -131,7 +146,7 @@ namespace Eigen
 			{
 				return {
 					a, { a.rows(), a.cols(), internal::scalar_constant_op<Rhs>{ b } },
-					{ std::forward<Urng>(urng), static_cast<DerivedGen&>(*this) }
+					{ std::forward<Urng>(urng), derived() }
 				};
 			}
 
@@ -143,7 +158,7 @@ namespace Eigen
 			{
 				return {
 					{ b.rows(), b.cols(), internal::scalar_constant_op<Lhs>{ a } }, b,
-					{ std::forward<Urng>(urng), static_cast<DerivedGen&>(*this) }
+					{ std::forward<Urng>(urng), derived() }
 				};
 			}
 		};
@@ -160,9 +175,14 @@ namespace Eigen
 		{
 		public:
 			/**
+			 * @brief Return a reference to the derived type.
+			 */
+			DerivedGen &derived() { return static_cast<DerivedGen &>(*this); }
+
+			/**
 			 * @brief returns the dimensions of vectors to be generated
 			 */
-			Index dims() const { return static_cast<DerivedGen&>(*this).dims(); }
+			Index dims() const { return derived().dims(); }
 
 			/**
 			 * @brief generates multiple samples at once
@@ -176,7 +196,7 @@ namespace Eigen
 			template<typename Urng>
 			inline Matrix<_Scalar, Dim, -1> generate(Urng&& urng, Index samples)
 			{
-				return static_cast<DerivedGen&>(*this).generatr(std::forward<Urng>(urng), samples);
+				return derived().generate(std::forward<Urng>(urng), samples);
 			}
 
 			/**
@@ -189,7 +209,7 @@ namespace Eigen
 			template<typename Urng>
 			inline Matrix<_Scalar, Dim, 1> generate(Urng&& urng)
 			{
-				return static_cast<DerivedGen&>(*this).generatr(std::forward<Urng>(urng));
+				return derived().generate(std::forward<Urng>(urng));
 			}
 		};
 
@@ -205,9 +225,14 @@ namespace Eigen
 		{
 		public:
 			/**
+			 * @brief Return a reference to the derived type.
+			 */
+			DerivedGen &derived() { return static_cast<DerivedGen &>(*this); }
+
+			/**
 			 * @brief returns the dimensions of matrices to be generated
 			 */
-			Index dims() const { return static_cast<DerivedGen&>(*this).dims(); }
+			Index dims() const { return derived().dims(); }
 
 			/**
 			 * @brief generates multiple samples at once
@@ -221,7 +246,7 @@ namespace Eigen
 			template<typename Urng>
 			inline Matrix<_Scalar, Dim, -1> generate(Urng&& urng, Index samples)
 			{
-				return static_cast<DerivedGen&>(*this).generate(std::forward<Urng>(urng), samples);
+				return derived().generate(std::forward<Urng>(urng), samples);
 			}
 
 			/**
@@ -234,7 +259,7 @@ namespace Eigen
 			template<typename Urng>
 			inline Matrix<_Scalar, Dim, Dim> generate(Urng&& urng)
 			{
-				return static_cast<DerivedGen&>(*this).generate(std::forward<Urng>(urng));
+				return derived().generate(std::forward<Urng>(urng));
 			}
 		};
 

--- a/EigenRand/MvDists/MvNormal.h
+++ b/EigenRand/MvDists/MvNormal.h
@@ -115,6 +115,20 @@ namespace Eigen
 			}
 		};
 
+    namespace detail {
+      template<typename MeanTy, typename CovTy>
+      constexpr bool either_is_dynamic() {
+        return (MatrixBase<MeanTy>::RowsAtCompileTime == Eigen::Dynamic) ||
+                (MatrixBase<CovTy>::RowsAtCompileTime == Eigen::Dynamic);
+      }
+
+      template<typename MeanTy, typename CovTy>
+      constexpr bool normal_check_dims() {
+        return (either_is_dynamic<MeanTy, CovTy>() || MatrixBase<MeanTy>::RowsAtCompileTime == MatrixBase<CovTy>::RowsAtCompileTime) &&
+               MatrixBase<CovTy>::RowsAtCompileTime == MatrixBase<CovTy>::ColsAtCompileTime;
+      }
+    }
+
 		/**
 		 * @brief helper function constructing Eigen::Rand::MvNormal
 		 * 
@@ -132,8 +146,7 @@ namespace Eigen
 				"Derived::Scalar must be the same with `mean` and `cov`'s Scalar."
 			);
 			static_assert(
-				MatrixBase<MeanTy>::RowsAtCompileTime == MatrixBase<CovTy>::RowsAtCompileTime &&
-				MatrixBase<CovTy>::RowsAtCompileTime == MatrixBase<CovTy>::ColsAtCompileTime,
+        detail::normal_check_dims<MeanTy, CovTy>(),
 				"assert: mean.RowsAtCompileTime == cov.RowsAtCompileTime && cov.RowsAtCompileTime == cov.ColsAtCompileTime"
 			);
 			return { mean, cov };
@@ -156,8 +169,7 @@ namespace Eigen
 				"Derived::Scalar must be the same with `mean` and `lt`'s Scalar."
 			);
 			static_assert(
-				MatrixBase<MeanTy>::RowsAtCompileTime == MatrixBase<LTTy>::RowsAtCompileTime &&
-				MatrixBase<LTTy>::RowsAtCompileTime == MatrixBase<LTTy>::ColsAtCompileTime,
+        detail::normal_check_dims<MeanTy, LTTy>(),
 				"assert: mean.RowsAtCompileTime == lt.RowsAtCompileTime && lt.RowsAtCompileTime == lt.ColsAtCompileTime"
 			);
 			return { mean, lt, lower_triangular };


### PR DESCRIPTION
+  returns reference to derived type to avoid static_cast everywhere
+ fix typo ".generatr" -> ".generate" in MvVecGenBase (this fixes use of function templates of the form `ret_type f(MvVecGenBase<Derived>&&)`)