### PR TITLE
Add EIGENRAND_BUILD_BENCHMARK cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,10 @@ project(EigenRand VERSION 0.5.0 DESCRIPTION "EigenRand, Random Number Generator 
 
 include(GNUInstallDirs)
 include(FetchContent)
+enable_testing()
 
 option(EIGENRAND_BUILD_TEST  "Build Test sets" ON)
+option(EIGENRAND_BUILD_BENCHMARK  "Build Benchmark sets" ON)
 
 option(EIGENRAND_CMAKE_VERBOSE "Define flags for cmake verbosity" OFF)
 
@@ -97,20 +99,22 @@ target_include_directories(eigenrand INTERFACE
 )
 add_library(EigenRand::EigenRand ALIAS eigenrand)
 
-set(ITEMS
-  benchmark/benchmark.cpp
-  benchmark/benchmark_mv.cpp
-  benchmark/benchmark_disc.cpp
-  benchmark/benchmark_vectorize_over_params.cpp
-  benchmark/accuracy.cpp
-)
-foreach(app ${ITEMS})
-  get_filename_component(app_name ${app} NAME_WE)
-  add_executable(${PROJECT_NAME}-${app_name} ${app})
-  target_link_libraries(${PROJECT_NAME}-${app_name} PRIVATE eigenrand)
-  install(TARGETS ${PROJECT_NAME}-${app_name} DESTINATION bin)
-  add_test(NAME ${PROJECT_NAME}-${app_name} COMMAND ${PROJECT_NAME}-${app_name})
-endforeach()
+if(EIGENRAND_BUILD_BENCHMARK)
+  set(ITEMS
+    benchmark/benchmark.cpp
+    benchmark/benchmark_mv.cpp
+    benchmark/benchmark_disc.cpp
+    benchmark/benchmark_vectorize_over_params.cpp
+    benchmark/accuracy.cpp
+  )
+  foreach(app ${ITEMS})
+    get_filename_component(app_name ${app} NAME_WE)
+    add_executable(${PROJECT_NAME}-${app_name} ${app})
+    target_link_libraries(${PROJECT_NAME}-${app_name} PRIVATE eigenrand)
+    install(TARGETS ${PROJECT_NAME}-${app_name} DESTINATION bin)
+    add_test(NAME ${PROJECT_NAME}-${app_name} COMMAND ${PROJECT_NAME}-${app_name})
+  endforeach()
+endif()
 
 
 set(FETCHCONTENT_SOURCE_DIR_GOOGLETEST ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
@@ -122,7 +126,6 @@ if(EIGENRAND_BUILD_TEST)
   if (NOT TARGET gtest)
     message(STATUS FATAL_ERROR "gtest target not found, is there a problem with googltest?")
   endif()
-  enable_testing()
   add_subdirectory( test )
 endif()
 

--- a/EigenRand/MorePacketMath.h
+++ b/EigenRand/MorePacketMath.h
@@ -13,6 +13,7 @@
 #define EIGENRAND_MORE_PACKET_MATH_H
 
 #include <Eigen/Dense>
+#include <cstdint>
 
 #define EIGENRAND_PRINT_PACKET(p) do { using _MTy = typename std::remove_const<typename std::remove_reference<decltype(p)>::type>::type; typename std::conditional<Eigen::internal::IsFloatPacket<_MTy>::value, float, typename std::conditional<Eigen::internal::IsDoublePacket<_MTy>::value, double, int>::type>::type f[4]; Eigen::internal::pstore(f, p); std::cout << #p " " << f[0] << " " << f[1] << " " << f[2] << " " << f[3] << std::endl; } while(0)
 


### PR DESCRIPTION
Hello @bab2min,

Here a PR to turn benchmark building optional.
Today, when using EigenRand as a submodule or with FetchContent, EigenRand benchmark are added to the main project test.
With this PR, we can disable them, and avoid running it.

Thanks !